### PR TITLE
feat: 포토(앨범) 도메인 API 모킹하기

### DIFF
--- a/photo-service/src/main/java/kr/mafoo/photo/api/AlbumApi.java
+++ b/photo-service/src/main/java/kr/mafoo/photo/api/AlbumApi.java
@@ -1,0 +1,46 @@
+package kr.mafoo.photo.api;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import kr.mafoo.photo.controller.dto.request.AlbumCreateRequest;
+import kr.mafoo.photo.controller.dto.request.AlbumUpdateRequest;
+import kr.mafoo.photo.controller.dto.response.AlbumResponse;
+import org.springframework.web.bind.annotation.*;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+
+@Tag(name = "앨범 관련 API", description = "앨범 조회, 생성, 수정, 삭제 등 API")
+@RequestMapping("/v1/albums")
+public interface AlbumApi {
+    @Operation(summary = "앨범 조회", description = "앨범 목록을 조회합니다.")
+    @GetMapping
+    Flux<AlbumResponse> getAlbums(
+    );
+
+    @Operation(summary = "앨범 생성", description = "앨범을 생성합니다.")
+    @PostMapping("")
+    Mono<AlbumResponse> createAlbum(
+            @RequestBody
+            AlbumCreateRequest request
+    );
+
+    @Operation(summary = "앨범 수정", description = "앨범의 이름 및 종류를 수정합니다.")
+    @PutMapping("/{albumId}")
+    Mono<AlbumResponse> updateAlbum(
+            @Parameter(description = "앨범 ID", example = "test_album_id")
+            @PathVariable
+            String albumId,
+
+            @RequestBody
+            AlbumUpdateRequest request
+    );
+
+    @Operation(summary = "앨범 삭제", description = "앨범을 삭제합니다.")
+    @DeleteMapping("/{albumId}")
+    Mono<Void> deleteAlbum(
+            @Parameter(description = "앨범 ID", example = "test_album_id")
+            @PathVariable
+            String albumId
+    );
+}

--- a/photo-service/src/main/java/kr/mafoo/photo/api/AlbumApi.java
+++ b/photo-service/src/main/java/kr/mafoo/photo/api/AlbumApi.java
@@ -19,7 +19,7 @@ public interface AlbumApi {
     );
 
     @Operation(summary = "앨범 생성", description = "앨범을 생성합니다.")
-    @PostMapping("")
+    @PostMapping
     Mono<AlbumResponse> createAlbum(
             @RequestBody
             AlbumCreateRequest request

--- a/photo-service/src/main/java/kr/mafoo/photo/api/PhotoApi.java
+++ b/photo-service/src/main/java/kr/mafoo/photo/api/PhotoApi.java
@@ -22,7 +22,7 @@ public interface PhotoApi {
     );
 
     @Operation(summary = "사진 생성", description = "사진을 생성합니다.")
-    @PostMapping("")
+    @PostMapping
     Mono<PhotoResponse> createPhoto(
             @RequestBody
             PhotoCreateRequest request

--- a/photo-service/src/main/java/kr/mafoo/photo/api/PhotoApi.java
+++ b/photo-service/src/main/java/kr/mafoo/photo/api/PhotoApi.java
@@ -1,0 +1,49 @@
+package kr.mafoo.photo.api;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import kr.mafoo.photo.controller.dto.request.PhotoCreateRequest;
+import kr.mafoo.photo.controller.dto.request.PhotoAlbumUpdateRequest;
+import kr.mafoo.photo.controller.dto.response.PhotoResponse;
+import org.springframework.web.bind.annotation.*;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+
+@Tag(name = "사진 관련 API", description = "사진 조회, 생성, 수정, 삭제 등 API")
+@RequestMapping("/v1/photos")
+public interface PhotoApi {
+    @Operation(summary = "사진 조회", description = "사진 목록을 조회합니다.")
+    @GetMapping
+    Flux<PhotoResponse> getAlbumPhotos(
+            @Parameter(description = "앨범 ID", example = "test_album_id")
+            @RequestParam(required = false)
+            String albumId
+    );
+
+    @Operation(summary = "사진 생성", description = "사진을 생성합니다.")
+    @PostMapping("")
+    Mono<PhotoResponse> createPhoto(
+            @RequestBody
+            PhotoCreateRequest request
+    );
+
+    @Operation(summary = "사진 앨범 수정", description = "사진을 다른 앨범으로 이동시킵니다.")
+    @PatchMapping("/{photoId}/album")
+    Mono<PhotoResponse> updatePhotoAlbum(
+            @Parameter(description = "사진 ID", example = "test_photo_id")
+            @PathVariable
+            String photoId,
+
+            @RequestBody
+            PhotoAlbumUpdateRequest request
+    );
+
+    @Operation(summary = "사진 삭제", description = "사진을 삭제합니다.")
+    @DeleteMapping("{photoId}")
+    Mono<Void> deletePhoto(
+            @Parameter(description = "사진 ID", example = "test_photo_id")
+            @PathVariable
+            String photoId
+    );
+}

--- a/photo-service/src/main/java/kr/mafoo/photo/config/SpringSecurityConfig.java
+++ b/photo-service/src/main/java/kr/mafoo/photo/config/SpringSecurityConfig.java
@@ -17,6 +17,7 @@ public class SpringSecurityConfig {
                 .authorizeExchange(exchanges -> exchanges
                         .anyExchange().permitAll()
                 )
+                .csrf(ServerHttpSecurity.CsrfSpec::disable)
                 .httpBasic(withDefaults())
                 .formLogin(withDefaults());
         return http.build();

--- a/photo-service/src/main/java/kr/mafoo/photo/controller/AlbumController.java
+++ b/photo-service/src/main/java/kr/mafoo/photo/controller/AlbumController.java
@@ -1,0 +1,55 @@
+package kr.mafoo.photo.controller;
+
+import kr.mafoo.photo.api.AlbumApi;
+import kr.mafoo.photo.controller.dto.request.AlbumCreateRequest;
+import kr.mafoo.photo.controller.dto.request.AlbumUpdateRequest;
+import kr.mafoo.photo.controller.dto.response.AlbumResponse;
+import org.springframework.web.bind.annotation.*;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+
+import static kr.mafoo.photo.domain.AlbumType.*;
+
+@RestController
+public class AlbumController implements AlbumApi {
+
+    @Override
+    public Flux<AlbumResponse> getAlbums(
+    ) {
+        return Flux.just(
+                new AlbumResponse("test_album_id_a", "단짝이랑", TYPE_A, "1"),
+                new AlbumResponse("test_album_id_b", "야뿌들", TYPE_B, "5"),
+                new AlbumResponse("test_album_id_c", "농구팟", TYPE_C, "2"),
+                new AlbumResponse("test_album_id_d", "화사사람들", TYPE_D, "12"),
+                new AlbumResponse("test_album_id_e", "기념일", TYPE_E, "4"),
+                new AlbumResponse("test_album_id_f", "친구들이랑", TYPE_F, "9")
+        );
+    }
+
+    @Override
+    public Mono<AlbumResponse> createAlbum(
+            AlbumCreateRequest request
+    ){
+        return Mono.just(
+                new AlbumResponse("test_album_id", "시금치파슷하", TYPE_A, "0")
+        );
+    }
+
+    @Override
+    public Mono<AlbumResponse> updateAlbum(
+            String albumId,
+            AlbumUpdateRequest request
+    ){
+        return Mono.just(
+                new AlbumResponse("test_album_id", "시금치파슷하", TYPE_A, "0")
+        );
+    }
+
+    @Override
+    public Mono<Void> deleteAlbum(
+            String albumId
+    ){
+        return Mono.empty();
+    }
+
+}

--- a/photo-service/src/main/java/kr/mafoo/photo/controller/PhotoController.java
+++ b/photo-service/src/main/java/kr/mafoo/photo/controller/PhotoController.java
@@ -1,0 +1,50 @@
+package kr.mafoo.photo.controller;
+
+import kr.mafoo.photo.api.PhotoApi;
+import kr.mafoo.photo.controller.dto.request.PhotoCreateRequest;
+import kr.mafoo.photo.controller.dto.request.PhotoAlbumUpdateRequest;
+import kr.mafoo.photo.controller.dto.response.PhotoResponse;
+import org.springframework.web.bind.annotation.RestController;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+
+@RestController
+public class PhotoController implements PhotoApi {
+
+    @Override
+    public Flux<PhotoResponse> getAlbumPhotos(
+            String albumId
+    ){
+        return Flux.just(
+                new PhotoResponse("test_photo_id_a", "test_album_id_a", "photo_url"),
+                new PhotoResponse("test_photo_id_b", "test_album_id_a", "photo_url"),
+                new PhotoResponse("test_photo_id_c", "test_album_id_a", "photo_url")
+        );
+    }
+
+    @Override
+    public Mono<PhotoResponse> createPhoto(
+            PhotoCreateRequest request
+    ){
+        return Mono.just(
+                new PhotoResponse("test_photo_id", "photo_url", null)
+        );
+    }
+
+    @Override
+    public Mono<PhotoResponse> updatePhotoAlbum(
+            String photoId,
+            PhotoAlbumUpdateRequest request
+    ){
+        return Mono.just(
+                new PhotoResponse("test_photo_id", "photo_url", "test_album_id")
+        );
+    }
+
+    @Override
+    public Mono<Void> deletePhoto(
+            String photoId
+    ){
+        return Mono.empty();
+    }
+}

--- a/photo-service/src/main/java/kr/mafoo/photo/controller/dto/request/AlbumCreateRequest.java
+++ b/photo-service/src/main/java/kr/mafoo/photo/controller/dto/request/AlbumCreateRequest.java
@@ -1,0 +1,13 @@
+package kr.mafoo.photo.controller.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "앨범 생성 요청")
+public record AlbumCreateRequest(
+        @Schema(description = "앨범 이름", example = "시금치파슷하")
+        String name,
+
+        @Schema(description = "앨범 타입", example = "TYPE_A")
+        String type
+) {
+}

--- a/photo-service/src/main/java/kr/mafoo/photo/controller/dto/request/AlbumUpdateRequest.java
+++ b/photo-service/src/main/java/kr/mafoo/photo/controller/dto/request/AlbumUpdateRequest.java
@@ -1,0 +1,13 @@
+package kr.mafoo.photo.controller.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "앨범 수정 요청")
+public record AlbumUpdateRequest(
+        @Schema(description = "앨범 이름", example = "시금치파슷하")
+        String name,
+
+        @Schema(description = "앨범 타입", example = "TYPE_A")
+        String type
+) {
+}

--- a/photo-service/src/main/java/kr/mafoo/photo/controller/dto/request/PhotoAlbumUpdateRequest.java
+++ b/photo-service/src/main/java/kr/mafoo/photo/controller/dto/request/PhotoAlbumUpdateRequest.java
@@ -1,0 +1,10 @@
+package kr.mafoo.photo.controller.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "사진 앨범 수정 요청")
+public record PhotoAlbumUpdateRequest(
+        @Schema(description = "앨범 ID", example = "test_album_id")
+        String albumId
+) {
+}

--- a/photo-service/src/main/java/kr/mafoo/photo/controller/dto/request/PhotoCreateRequest.java
+++ b/photo-service/src/main/java/kr/mafoo/photo/controller/dto/request/PhotoCreateRequest.java
@@ -1,0 +1,10 @@
+package kr.mafoo.photo.controller.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "사진 생성 요청")
+public record PhotoCreateRequest(
+        @Schema(description = "QR URL", example = "qr_url")
+        String qrUrl
+) {
+}

--- a/photo-service/src/main/java/kr/mafoo/photo/controller/dto/response/AlbumResponse.java
+++ b/photo-service/src/main/java/kr/mafoo/photo/controller/dto/response/AlbumResponse.java
@@ -1,0 +1,20 @@
+package kr.mafoo.photo.controller.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import kr.mafoo.photo.domain.AlbumType;
+
+@Schema(description = "앨범 응답")
+public record AlbumResponse(
+        @Schema(description = "앨범 ID", example = "test_album_id")
+        String albumId,
+
+        @Schema(description = "앨범 이름", example = "야뿌들")
+        String name,
+
+        @Schema(description = "앨범 종류", example = "TYPE_B")
+        AlbumType type,
+
+        @Schema(description = "앨범 내 사진 수", example = "6")
+        String photoCount
+) {
+}

--- a/photo-service/src/main/java/kr/mafoo/photo/controller/dto/response/PhotoResponse.java
+++ b/photo-service/src/main/java/kr/mafoo/photo/controller/dto/response/PhotoResponse.java
@@ -1,0 +1,16 @@
+package kr.mafoo.photo.controller.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "사진 응답")
+public record PhotoResponse(
+        @Schema(description = "사진 ID", example = "test_photo_id")
+        String photoId,
+
+        @Schema(description = "사진 URL", example = "photo_url")
+        String photoUrl,
+
+        @Schema(description = "앨범 ID", example = "test_album_id")
+        String albumId
+) {
+}

--- a/photo-service/src/main/java/kr/mafoo/photo/domain/AlbumType.java
+++ b/photo-service/src/main/java/kr/mafoo/photo/domain/AlbumType.java
@@ -1,0 +1,10 @@
+package kr.mafoo.photo.domain;
+
+public enum AlbumType {
+    TYPE_A,
+    TYPE_B,
+    TYPE_C,
+    TYPE_D,
+    TYPE_E,
+    TYPE_F,
+}


### PR DESCRIPTION
## ❓ 기능 추가 배경

포토(앨범) 도메인 프론트 문서를 위한 모킹을 하였습니다

## ➕ 추가/변경된 기능

- 사진(photo)
  - GET /v1/photos
  - POST /v1/photos
  - PATCH /v1/photos/{photoId}/album
  - DELETE /v1/photos/{photoId}

- 앨범(album)
  - GET /v1/albums
  - POST /v1/albums
  - PUT /v1/albums/{albumId}
  - DELETE /v1/albums/{albumId}

## 🥺 리뷰어에게 하고싶은 말
- PUT/PATCH 중에 어떤 메소드를 사용할지나, DTO 구성에서 '이게 최선일까?' 싶은 부분이 더러 있었는데, 시간 여건 상 깊게 고민을 못해봐서 아쉬운 부분들이 있어요... 보시고 더 좋은 대안이나 고칠 부분이 있다면 알려주세요 :)

- 모듈 이름을 'photo-service'에서 'photo-album-service'로 변경하면 너무 구구절절일까요?

## 🗎 관련 이슈

Closes #3