### PR TITLE
fix: 포토이즘 QR 사진 저장 로직 오류 수정

### DIFF
--- a/photo-service/src/main/java/kr/mafoo/photo/service/QrService.java
+++ b/photo-service/src/main/java/kr/mafoo/photo/service/QrService.java
@@ -63,13 +63,14 @@ public class QrService {
                             .post()
                             .uri("https://cmsapi.seobuk.kr/v1/etc/seq/resource")
                             .contentType(MediaType.APPLICATION_JSON)
-                            .bodyValue(Map.of("uid", uid, "appUserId", null))
+                            .bodyValue(Map.of("uid", uid))
                             .retrieve()
                             .bodyToMono(LinkedHashMap.class)
                             .flatMap(responseBody -> {
                                 LinkedHashMap<String, Object> content = (LinkedHashMap<String, Object>) responseBody.get("content");
                                 LinkedHashMap<String, Object> fileInfo = (LinkedHashMap<String, Object>) content.get("fileInfo");
-                                String imageUrl = (String) fileInfo.get("picFile.path");
+                                LinkedHashMap<String, Object> picFile = (LinkedHashMap<String, Object>) fileInfo.get("picFile");
+                                String imageUrl = (String) picFile.get("path");
 
                                 return getFileAsByte(imageUrl);
                             });


### PR DESCRIPTION
## ❓ 기능 추가 배경
포토이즘 사진 저장 로직 실행 시 ```PE003```로 반환되는 오류를 수정했습니다.

## ➕ 추가/변경된 기능
- 포토이즘 자체 POST api 호출 시 request의 body 수정 (null 항목 제거)
- 포토이즘 자체 POST api 호출 시 response의 body 내용 받아오는 로직 수정

## 🥺 리뷰어에게 하고싶은 말

## 🗎 관련 이슈
Closes #26