### PR TITLE
fix: 돈룩업 QR 사진 저장 로직 오류 수정

### DIFF
--- a/photo-service/src/main/java/kr/mafoo/photo/service/QrService.java
+++ b/photo-service/src/main/java/kr/mafoo/photo/service/QrService.java
@@ -91,7 +91,7 @@ public class QrService {
     }
 
     private Mono<byte[]> getDontLookUpFiles(String qrUrl) {
-        String imageName = extractValueFromUrl(qrUrl, ".kr/");
+        String imageName = extractValueFromUrl(qrUrl, ".kr/image/");
 
         String baseUrl = "https://x.dontlxxkup.kr/uploads/";
         String imageUrl = baseUrl + imageName;
@@ -107,7 +107,10 @@ public class QrService {
                     } else {
                         return getFileAsByte(imageUrl);
                     }
-                });
+                })
+                .onErrorResume(
+                        RedirectUriNotFoundException.class, e -> getFileAsByte(imageUrl)
+                );
     }
 
     private Mono<String> getRedirectUri(String url) {


### PR DESCRIPTION
## ❓ 기능 추가 배경
돈룩업 사진 저장 로직 실행 시 ```EX0001```로 반환되는 오류를 수정했습니다.

## ➕ 추가/변경된 기능
- 돈룩업 imageName 추출 구분자 수정
- 돈룩업 qrUrl 만료 여부 체크 로직 수정

## 🥺 리뷰어에게 하고싶은 말

## 🗎 관련 이슈
Closes #28