### PR TITLE
refactor: 미로그인 사용자도 QR 사진 저장이 가능하도록 Photo Table Null 여부 변경

### DIFF
--- a/photo-service/src/main/resources/db/migration/V5__changeOwnerMemberIdAsNullableInPhotoTable.sql
+++ b/photo-service/src/main/resources/db/migration/V5__changeOwnerMemberIdAsNullableInPhotoTable.sql
@@ -1,0 +1,2 @@
+alter table photo
+    modify owner_member_id char(26) null comment '사진소유자아이디';


### PR DESCRIPTION
## ❓ 기능 추가 배경
미로그인 사용자도 QR 사진 저장이 가능하도록 Photo Table Null 여부 변경을 했습니다.

## ➕ 추가/변경된 기능
- DB migration v5 생성 : ownerMemberId를 NOT NULL -> NULL로 변경

## 🥺 리뷰어에게 하고싶은 말


## 🗎 관련 이슈
Closes #39