### PR TITLE
[MAFOO-38] feat: 사진의 앨범 정보 등록 (사진 앨범 id 변경) 시 소유자가 없는 사진의 소유자 할당 로직 추가

### DIFF
--- a/photo-service/src/main/java/kr/mafoo/photo/domain/PhotoEntity.java
+++ b/photo-service/src/main/java/kr/mafoo/photo/domain/PhotoEntity.java
@@ -62,6 +62,11 @@ public class PhotoEntity implements Persistable<String> {
         return photoId;
     }
 
+    public PhotoEntity updateOwnerMemberId(String ownerMemberId) {
+        this.ownerMemberId = ownerMemberId;
+        return this;
+    }
+
     public PhotoEntity updateAlbumId(String albumId) {
         this.albumId = albumId;
         return this;

--- a/photo-service/src/main/java/kr/mafoo/photo/service/PhotoService.java
+++ b/photo-service/src/main/java/kr/mafoo/photo/service/PhotoService.java
@@ -37,7 +37,7 @@ public class PhotoService {
                 .findById(albumId)
                 .switchIfEmpty(Mono.error(new AlbumNotFoundException()))
                 .flatMapMany(albumEntity -> {
-                    if(!albumEntity.getOwnerMemberId().equals(requestMemberId)) {
+                    if (!albumEntity.getOwnerMemberId().equals(requestMemberId)) {
                         // 내 앨범이 아니면 그냥 없는 앨범 처리
                         return Mono.error(new AlbumNotFoundException());
                     } else {
@@ -51,7 +51,7 @@ public class PhotoService {
                 .findById(photoId)
                 .switchIfEmpty(Mono.error(new PhotoNotFoundException()))
                 .flatMap(photoEntity -> {
-                    if(!photoEntity.getOwnerMemberId().equals(requestMemberId)) {
+                    if (!photoEntity.getOwnerMemberId().equals(requestMemberId)) {
                         // 내 사진이 아니면 그냥 없는 사진 처리
                         return Mono.error(new PhotoNotFoundException());
                     } else {
@@ -66,7 +66,11 @@ public class PhotoService {
                 .findById(photoId)
                 .switchIfEmpty(Mono.error(new PhotoNotFoundException()))
                 .flatMap(photoEntity -> {
-                    if(!photoEntity.getOwnerMemberId().equals(requestMemberId)) {
+                    if (photoEntity.getOwnerMemberId() == null) {
+                        photoRepository.save(photoEntity.updateOwnerMemberId(requestMemberId));
+                    }
+
+                    if (!photoEntity.getOwnerMemberId().equals(requestMemberId)) {
                         // 내 사진이 아니면 그냥 없는 사진 처리
                         return Mono.error(new PhotoNotFoundException());
                     } else {
@@ -74,7 +78,7 @@ public class PhotoService {
                                 .findById(albumId)
                                 .switchIfEmpty(Mono.error(new AlbumNotFoundException()))
                                 .flatMap(albumEntity -> {
-                                    if(!albumEntity.getOwnerMemberId().equals(requestMemberId)) {
+                                    if (!albumEntity.getOwnerMemberId().equals(requestMemberId)) {
                                         // 내 앨범이 아니면 그냥 없는 앨범 처리
                                         return Mono.error(new AlbumNotFoundException());
                                     } else {


### PR DESCRIPTION
## ❓ 기능 추가 배경
비회원 유저 사용 플로우 관련 로직이 사진 앨범 ID 수정 api에 추가되었어요

## ➕ 추가/변경된 기능
- 사진의 앨범 정보 등록 (사진 앨범 id 변경) 시 소유자가 없는 사진의 소유자 할당 로직 추가

## 🥺 리뷰어에게 하고싶은 말


## 🗎 관련 이슈
[MAFOO-38](https://3spinachpasta.atlassian.net/browse/MAFOO-38)