### PR TITLE
[MAFOO-101] feat: 사진 순서 관련 API 기능 추가

### DIFF
--- a/photo-service/src/main/java/kr/mafoo/photo/api/PhotoApi.java
+++ b/photo-service/src/main/java/kr/mafoo/photo/api/PhotoApi.java
@@ -8,6 +8,7 @@ import kr.mafoo.photo.annotation.RequestMemberId;
 import kr.mafoo.photo.annotation.ULID;
 import kr.mafoo.photo.controller.dto.request.PhotoCreateRequest;
 import kr.mafoo.photo.controller.dto.request.PhotoUpdateAlbumIdRequest;
+import kr.mafoo.photo.controller.dto.request.PhotoUpdateDisplayIndexRequest;
 import kr.mafoo.photo.controller.dto.response.PhotoResponse;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
@@ -55,6 +56,22 @@ public interface PhotoApi {
             @Valid
             @RequestBody
             PhotoUpdateAlbumIdRequest request
+    );
+
+    @Operation(summary = "사진 표시 순서 변경", description = "사진의 표시 순서를 변경합니다.")
+    @PatchMapping("/{photoId}/display-index")
+    Mono<PhotoResponse> updatePhotoDisplayIndex(
+            @RequestMemberId
+            String memberId,
+
+            @ULID
+            @Parameter(description = "사진 ID", example = "test_photo_id")
+            @PathVariable
+            String photoId,
+
+            @Valid
+            @RequestBody
+            PhotoUpdateDisplayIndexRequest request
     );
 
     @Operation(summary = "사진 삭제", description = "사진을 삭제합니다.")

--- a/photo-service/src/main/java/kr/mafoo/photo/controller/PhotoController.java
+++ b/photo-service/src/main/java/kr/mafoo/photo/controller/PhotoController.java
@@ -3,14 +3,13 @@ package kr.mafoo.photo.controller;
 import kr.mafoo.photo.api.PhotoApi;
 import kr.mafoo.photo.controller.dto.request.PhotoCreateRequest;
 import kr.mafoo.photo.controller.dto.request.PhotoUpdateAlbumIdRequest;
+import kr.mafoo.photo.controller.dto.request.PhotoUpdateDisplayIndexRequest;
 import kr.mafoo.photo.controller.dto.response.PhotoResponse;
 import kr.mafoo.photo.service.PhotoService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.RestController;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
-
-import static kr.mafoo.photo.domain.BrandType.LIFE_FOUR_CUTS;
 
 @RequiredArgsConstructor
 @RestController
@@ -46,6 +45,17 @@ public class PhotoController implements PhotoApi {
     ){
         return photoService
                 .updatePhotoAlbumId(photoId, request.albumId(), memberId)
+                .map(PhotoResponse::fromEntity);
+    }
+
+    @Override
+    public Mono<PhotoResponse> updatePhotoDisplayIndex(
+            String memberId,
+            String photoId,
+            PhotoUpdateDisplayIndexRequest request
+    ) {
+        return photoService
+                .updatePhotoDisplayIndex(photoId, request.newDisplayIndex(), memberId)
                 .map(PhotoResponse::fromEntity);
     }
 

--- a/photo-service/src/main/java/kr/mafoo/photo/controller/dto/request/PhotoUpdateDisplayIndexRequest.java
+++ b/photo-service/src/main/java/kr/mafoo/photo/controller/dto/request/PhotoUpdateDisplayIndexRequest.java
@@ -1,0 +1,12 @@
+package kr.mafoo.photo.controller.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+
+@Schema(description = "사진 인덱스 수정 요청")
+public record PhotoUpdateDisplayIndexRequest(
+        @NotNull
+        @Schema(description = "사진 표시 인덱스", example = "photo_display_index")
+        Integer newDisplayIndex
+) {
+}

--- a/photo-service/src/main/java/kr/mafoo/photo/controller/dto/response/PhotoResponse.java
+++ b/photo-service/src/main/java/kr/mafoo/photo/controller/dto/response/PhotoResponse.java
@@ -16,7 +16,10 @@ public record PhotoResponse(
         BrandType brand,
 
         @Schema(description = "앨범 ID", example = "test_album_id")
-        String albumId
+        String albumId,
+
+        @Schema(description = "사진 표시 인덱스", example = "photo_display_index")
+        Integer displayIndex
 ) {
         public static PhotoResponse fromEntity(
                 PhotoEntity entity
@@ -25,7 +28,8 @@ public record PhotoResponse(
                         entity.getPhotoId(),
                         entity.getPhotoUrl(),
                         entity.getBrand(),
-                        entity.getAlbumId()
+                        entity.getAlbumId(),
+                        entity.getDisplayIndex()
                 );
         }
 }

--- a/photo-service/src/main/java/kr/mafoo/photo/domain/PhotoEntity.java
+++ b/photo-service/src/main/java/kr/mafoo/photo/domain/PhotoEntity.java
@@ -32,6 +32,9 @@ public class PhotoEntity implements Persistable<String> {
     @Column("album_id")
     private String albumId;
 
+    @Column("display_index")
+    private Integer displayIndex;
+
     @CreatedDate
     @Column("created_at")
     private LocalDateTime createdAt;

--- a/photo-service/src/main/java/kr/mafoo/photo/domain/PhotoEntity.java
+++ b/photo-service/src/main/java/kr/mafoo/photo/domain/PhotoEntity.java
@@ -79,6 +79,11 @@ public class PhotoEntity implements Persistable<String> {
         return this;
     }
 
+    public PhotoEntity updateDisplayIndex(Integer displayIndex) {
+        this.displayIndex = displayIndex;
+        return this;
+    }
+
     public static PhotoEntity newPhoto(String photoId, String photoUrl, BrandType brandType, String ownerMemberId) {
         PhotoEntity photo = new PhotoEntity();
         photo.photoId = photoId;

--- a/photo-service/src/main/java/kr/mafoo/photo/exception/ErrorCode.java
+++ b/photo-service/src/main/java/kr/mafoo/photo/exception/ErrorCode.java
@@ -12,8 +12,9 @@ public enum ErrorCode {
 
     ALBUM_NOT_FOUND("AE0001", "앨범을 찾을 수 없습니다"),
     PHOTO_NOT_FOUND("PE0001", "사진을 찾을 수 없습니다"),
-    PHOTO_BRAND_NOT_EXISTS("PE002", "사진 브랜드가 존재하지 않습니다"),
-    PHOTO_QR_URL_EXPIRED("PE003", "사진 저장을 위한 QR URL이 만료되었습니다"),
+    PHOTO_BRAND_NOT_EXISTS("PE0002", "사진 브랜드가 존재하지 않습니다"),
+    PHOTO_QR_URL_EXPIRED("PE0003", "사진 저장을 위한 QR URL이 만료되었습니다"),
+    PHOTO_DISPLAY_INDEX_IS_SAME("PE0004", "옮기려는 대상 사진 인덱스가 같습니다"),
 
     ;
     private final String code;

--- a/photo-service/src/main/java/kr/mafoo/photo/exception/ErrorCode.java
+++ b/photo-service/src/main/java/kr/mafoo/photo/exception/ErrorCode.java
@@ -15,6 +15,7 @@ public enum ErrorCode {
     PHOTO_BRAND_NOT_EXISTS("PE0002", "사진 브랜드가 존재하지 않습니다"),
     PHOTO_QR_URL_EXPIRED("PE0003", "사진 저장을 위한 QR URL이 만료되었습니다"),
     PHOTO_DISPLAY_INDEX_IS_SAME("PE0004", "옮기려는 대상 사진 인덱스가 같습니다"),
+    PHOTO_DISPLAY_INDEX_NOT_VALID("PE0005", "옮기려는 대상 사진 인덱스가 유효하지 않습니다"),
 
     ;
     private final String code;

--- a/photo-service/src/main/java/kr/mafoo/photo/exception/PhotoDisplayIndexIsSameException.java
+++ b/photo-service/src/main/java/kr/mafoo/photo/exception/PhotoDisplayIndexIsSameException.java
@@ -1,0 +1,7 @@
+package kr.mafoo.photo.exception;
+
+public class PhotoDisplayIndexIsSameException extends DomainException {
+    public PhotoDisplayIndexIsSameException() {
+        super(ErrorCode.PHOTO_DISPLAY_INDEX_IS_SAME);
+    }
+}

--- a/photo-service/src/main/java/kr/mafoo/photo/exception/PhotoDisplayIndexNotValidException.java
+++ b/photo-service/src/main/java/kr/mafoo/photo/exception/PhotoDisplayIndexNotValidException.java
@@ -1,0 +1,7 @@
+package kr.mafoo.photo.exception;
+
+public class PhotoDisplayIndexNotValidException extends DomainException {
+    public PhotoDisplayIndexNotValidException() {
+        super(ErrorCode.PHOTO_DISPLAY_INDEX_NOT_VALID);
+    }
+}

--- a/photo-service/src/main/java/kr/mafoo/photo/repository/PhotoRepository.java
+++ b/photo-service/src/main/java/kr/mafoo/photo/repository/PhotoRepository.java
@@ -13,4 +13,12 @@ public interface PhotoRepository extends R2dbcRepository<PhotoEntity, String> {
     @Modifying
     @Query("UPDATE photo SET display_index = display_index - 1 WHERE album_id = :albumId AND display_index > :startIndex")
     Mono<Void> popDisplayIndexGreaterThan(String albumId, int startIndex);
+
+    @Modifying
+    @Query("UPDATE photo SET display_index = display_index - 1 WHERE album_id = :albumId AND display_index BETWEEN :startIndex AND :endIndex")
+    Mono<Void> popDisplayIndexBetween(String albumId, int startIndex, int endIndex);
+
+    @Modifying
+    @Query("UPDATE photo SET display_index = display_index + 1 WHERE album_id = :albumId AND display_index BETWEEN :startIndex AND :endIndex")
+    Mono<Void> pushDisplayIndexBetween(String albumId, int startIndex, int endIndex);
 }

--- a/photo-service/src/main/java/kr/mafoo/photo/repository/PhotoRepository.java
+++ b/photo-service/src/main/java/kr/mafoo/photo/repository/PhotoRepository.java
@@ -1,9 +1,16 @@
 package kr.mafoo.photo.repository;
 
 import kr.mafoo.photo.domain.PhotoEntity;
+import org.springframework.data.r2dbc.repository.Modifying;
+import org.springframework.data.r2dbc.repository.Query;
 import org.springframework.data.r2dbc.repository.R2dbcRepository;
 import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
 
 public interface PhotoRepository extends R2dbcRepository<PhotoEntity, String> {
     Flux<PhotoEntity> findAllByAlbumIdOrderByDisplayIndexDesc(String ownerAlbumId);
+
+    @Modifying
+    @Query("UPDATE photo SET display_index = display_index - 1 WHERE album_id = :albumId AND display_index > :startIndex")
+    Mono<Void> popDisplayIndexGreaterThan(String albumId, int startIndex);
 }

--- a/photo-service/src/main/java/kr/mafoo/photo/repository/PhotoRepository.java
+++ b/photo-service/src/main/java/kr/mafoo/photo/repository/PhotoRepository.java
@@ -5,5 +5,5 @@ import org.springframework.data.r2dbc.repository.R2dbcRepository;
 import reactor.core.publisher.Flux;
 
 public interface PhotoRepository extends R2dbcRepository<PhotoEntity, String> {
-    Flux<PhotoEntity> findAllByAlbumId(String ownerAlbumId);
+    Flux<PhotoEntity> findAllByAlbumIdOrderByDisplayIndexDesc(String ownerAlbumId);
 }

--- a/photo-service/src/main/java/kr/mafoo/photo/service/PhotoService.java
+++ b/photo-service/src/main/java/kr/mafoo/photo/service/PhotoService.java
@@ -91,8 +91,13 @@ public class PhotoService {
                                         return Mono.error(new AlbumNotFoundException());
                                     } else {
                                         return albumService.decreaseAlbumPhotoCount(photoEntity.getAlbumId(), requestMemberId)
+                                                .then(photoRepository.popDisplayIndexGreaterThan(photoEntity.getAlbumId(), photoEntity.getDisplayIndex()))
                                                 .then(albumService.increaseAlbumPhotoCount(albumId, requestMemberId))
-                                                .then(photoRepository.save(photoEntity.updateAlbumId(albumId)));
+                                                .then(photoRepository.save(
+                                                        photoEntity.updateAlbumId(albumId)
+                                                                .updateDisplayIndex(albumEntity.getPhotoCount())
+                                                        )
+                                                );
                                     }
                                 });
                     }

--- a/photo-service/src/main/java/kr/mafoo/photo/service/PhotoService.java
+++ b/photo-service/src/main/java/kr/mafoo/photo/service/PhotoService.java
@@ -60,8 +60,9 @@ public class PhotoService {
                         // 내 사진이 아니면 그냥 없는 사진 처리
                         return Mono.error(new PhotoNotFoundException());
                     } else {
-                        return photoRepository.deleteById(photoId)
-                                .then(albumService.decreaseAlbumPhotoCount(photoEntity.getAlbumId(), requestMemberId));
+                        return albumService.decreaseAlbumPhotoCount(photoEntity.getAlbumId(), requestMemberId)
+                                .then(photoRepository.popDisplayIndexGreaterThan(photoEntity.getAlbumId(), photoEntity.getDisplayIndex()))
+                                .then(photoRepository.deleteById(photoId));
                     }
                 });
     }

--- a/photo-service/src/main/java/kr/mafoo/photo/service/PhotoService.java
+++ b/photo-service/src/main/java/kr/mafoo/photo/service/PhotoService.java
@@ -2,6 +2,7 @@ package kr.mafoo.photo.service;
 
 import kr.mafoo.photo.domain.PhotoEntity;
 import kr.mafoo.photo.exception.AlbumNotFoundException;
+import kr.mafoo.photo.exception.PhotoDisplayIndexIsSameException;
 import kr.mafoo.photo.exception.PhotoNotFoundException;
 import kr.mafoo.photo.repository.AlbumRepository;
 import kr.mafoo.photo.repository.PhotoRepository;
@@ -113,6 +114,10 @@ public class PhotoService {
                         .findById(photoEntity.getAlbumId())
                         .switchIfEmpty(Mono.error(new AlbumNotFoundException()))
                         .flatMap(albumEntity -> {
+
+                            if (photoEntity.getDisplayIndex().equals(newIndex)) {
+                                return Mono.error(new PhotoDisplayIndexIsSameException());
+                            }
 
                             if (photoEntity.getDisplayIndex() < newIndex) {
                                 return photoRepository

--- a/photo-service/src/main/java/kr/mafoo/photo/service/PhotoService.java
+++ b/photo-service/src/main/java/kr/mafoo/photo/service/PhotoService.java
@@ -3,6 +3,7 @@ package kr.mafoo.photo.service;
 import kr.mafoo.photo.domain.PhotoEntity;
 import kr.mafoo.photo.exception.AlbumNotFoundException;
 import kr.mafoo.photo.exception.PhotoDisplayIndexIsSameException;
+import kr.mafoo.photo.exception.PhotoDisplayIndexNotValidException;
 import kr.mafoo.photo.exception.PhotoNotFoundException;
 import kr.mafoo.photo.repository.AlbumRepository;
 import kr.mafoo.photo.repository.PhotoRepository;
@@ -117,6 +118,10 @@ public class PhotoService {
 
                             if (photoEntity.getDisplayIndex().equals(newIndex)) {
                                 return Mono.error(new PhotoDisplayIndexIsSameException());
+                            }
+
+                            if (newIndex < 0 || newIndex >= albumEntity.getPhotoCount()) {
+                                return Mono.error(new PhotoDisplayIndexNotValidException());
                             }
 
                             if (photoEntity.getDisplayIndex() < newIndex) {

--- a/photo-service/src/main/java/kr/mafoo/photo/service/PhotoService.java
+++ b/photo-service/src/main/java/kr/mafoo/photo/service/PhotoService.java
@@ -45,7 +45,7 @@ public class PhotoService {
                         // 내 앨범이 아니면 그냥 없는 앨범 처리
                         return Mono.error(new AlbumNotFoundException());
                     } else {
-                        return photoRepository.findAllByAlbumId(albumId);
+                        return photoRepository.findAllByAlbumIdOrderByDisplayIndexDesc(albumId);
                     }
                 });
     }

--- a/photo-service/src/main/resources/db/migration/V7__addDisplayIndexColumnInPhotoTable.sql
+++ b/photo-service/src/main/resources/db/migration/V7__addDisplayIndexColumnInPhotoTable.sql
@@ -1,0 +1,20 @@
+ALTER TABLE `photo`
+    ADD `display_index` INTEGER COMMENT '표시순' AFTER `album_id`;
+
+CREATE INDEX `idx_photo_display_index` ON `photo`(`display_index`);
+
+WITH RankedPhotos AS (
+    SELECT
+        id,
+        owner_member_id,
+        album_id,
+        CASE
+            WHEN album_id IS NOT NULL THEN ROW_NUMBER() OVER (PARTITION BY owner_member_id, album_id ORDER BY created_at) - 1
+            ELSE NULL
+            END AS new_index
+    FROM photo
+)
+UPDATE photo
+    JOIN RankedPhotos
+ON photo.id = RankedPhotos.id
+    SET photo.display_index = RankedPhotos.new_index;


### PR DESCRIPTION
## ❓ 기능 추가 배경
사진에 사용자가 커스텀 가능한 표시 순서를 추가했어요

## ➕ 추가/변경된 기능
- (변경) GET /v1/photos?albumId={albumId}
  - 표시 인덱스(display_index)를 response dto에 추가
- (변경) PATCH /v1/photos/{photoId}/album
  - 기존 앨범 내부 사진 인덱스 변경 로직 추가
  - 옮기는 대상 사진의 인덱스 변경 로직 추가
- (변경) DELETE /v1/photos/{photoId}
  - 기존 앨범 내부 사진 인덱스 변경 로직 추가
- (추가) PATCH /v1/photos/{photoId}/display-index

## 🥺 리뷰어에게 하고싶은 말


## 🗎 관련 이슈
[MAFOO-101](https://3spinachpasta.atlassian.net/browse/MAFOO-101?atlOrigin=eyJpIjoiMGE1YmNiMjY2NWQ5NGY0OTg2MTAwNjE4MTQwNjRmZGYiLCJwIjoiaiJ9)