### PR TITLE
[MAFOO-143] fix: 회원 탈퇴 API에 social member 레코드 삭제 로직을 추가했어요

### DIFF
--- a/user-service/src/main/java/kr/mafoo/user/repository/SocialMemberRepository.java
+++ b/user-service/src/main/java/kr/mafoo/user/repository/SocialMemberRepository.java
@@ -8,4 +8,5 @@ import reactor.core.publisher.Mono;
 
 public interface SocialMemberRepository extends R2dbcRepository<SocialMemberEntity, SocialMemberEntityKey> {
     Mono<SocialMemberEntity> findByIdentityProviderAndId(IdentityProvider identityProvider, String id);
+    Mono<SocialMemberEntity> findByMemberId(String memberId);
 }

--- a/user-service/src/main/java/kr/mafoo/user/service/MemberService.java
+++ b/user-service/src/main/java/kr/mafoo/user/service/MemberService.java
@@ -3,6 +3,7 @@ package kr.mafoo.user.service;
 import kr.mafoo.user.domain.MemberEntity;
 import kr.mafoo.user.exception.MemberNotFoundException;
 import kr.mafoo.user.repository.MemberRepository;
+import kr.mafoo.user.repository.SocialMemberRepository;
 import kr.mafoo.user.util.IdGenerator;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -15,10 +16,14 @@ import reactor.core.publisher.Mono;
 @Service
 public class MemberService {
     private final MemberRepository memberRepository;
+    private final SocialMemberRepository socialMemberRepository;
     private final SlackService slackService;
 
     public Mono<Void> quitMemberByMemberId(String memberId) {
-        return memberRepository.deleteMemberById(memberId);
+        return socialMemberRepository
+                .findByMemberId(memberId)
+                .flatMap(socialMemberRepository::delete)
+                .then(memberRepository.deleteMemberById(memberId));
     }
 
     public Mono<MemberEntity> getMemberByMemberId(String memberId) {


### PR DESCRIPTION
## ❓ 기능 추가 배경
회원 탈퇴 API에 social member 레코드 삭제 로직을 추가했어요

## ➕ 추가/변경된 기능
- 회원 탈퇴 API : social member 삭제 로직 추가

## 🥺 리뷰어에게 하고싶은 말
마푸 최고~

## 🗎 관련 이슈
[MAFOO-143](https://3spinachpasta.atlassian.net/browse/MAFOO-143)