### PR TITLE
[M25-22] refactor: SOFT DELETE이 가능하도록 전반적인 로직을 수정했어요

### DIFF
--- a/photo-service/src/main/java/kr/mafoo/photo/api/MemberDataApi.java
+++ b/photo-service/src/main/java/kr/mafoo/photo/api/MemberDataApi.java
@@ -1,0 +1,22 @@
+package kr.mafoo.photo.api;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import kr.mafoo.photo.annotation.RequestMemberId;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import reactor.core.publisher.Flux;
+
+@Validated
+@Tag(name = "사용자 데이터 API", description = "회원 탈퇴 시 사용하는 API")
+@RequestMapping("/v1/member-data")
+public interface MemberDataApi {
+
+    @Operation(summary = "사용자 데이터 삭제", description = "사용자와 관련된 앨범, 사진, 공유 사용자 데이터를 삭제합니다.")
+    @DeleteMapping
+    Flux<Void> deleteMemberData(
+            @RequestMemberId
+            String memberId
+    );
+}

--- a/photo-service/src/main/java/kr/mafoo/photo/controller/AlbumController.java
+++ b/photo-service/src/main/java/kr/mafoo/photo/controller/AlbumController.java
@@ -8,6 +8,7 @@ import kr.mafoo.photo.controller.dto.response.AlbumDetailResponse;
 import kr.mafoo.photo.controller.dto.response.AlbumResponse;
 import kr.mafoo.photo.controller.dto.response.SharedAlbumResponse;
 import kr.mafoo.photo.service.AlbumService;
+import kr.mafoo.photo.service.EventService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.server.reactive.ServerHttpRequest;
 import org.springframework.web.bind.annotation.RestController;
@@ -19,6 +20,7 @@ import reactor.core.publisher.Mono;
 public class AlbumController implements AlbumApi {
 
     private final AlbumService albumService;
+    private final EventService eventService;
 
     @Override
     public Flux<AlbumDetailResponse> getAlbumListByMember(
@@ -54,7 +56,7 @@ public class AlbumController implements AlbumApi {
             throw new RuntimeException(); // should not be happened
         }
         if(request.sumoneInviteCode() != null) {
-            return albumService
+            return eventService
                     .addSumoneAlbum(request.name(), request.type(), memberId, request.sumoneInviteCode())
                     .map(AlbumResponse::fromEntity);
         }

--- a/photo-service/src/main/java/kr/mafoo/photo/controller/MemberDataController.java
+++ b/photo-service/src/main/java/kr/mafoo/photo/controller/MemberDataController.java
@@ -1,0 +1,21 @@
+package kr.mafoo.photo.controller;
+
+import kr.mafoo.photo.api.MemberDataApi;
+import kr.mafoo.photo.service.MemberDataService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.RestController;
+import reactor.core.publisher.Flux;
+
+@RequiredArgsConstructor
+@RestController
+public class MemberDataController implements MemberDataApi {
+
+    private final MemberDataService memberDataService;
+
+    @Override
+    public Flux<Void> deleteMemberData(
+            String memberId
+    ){
+        return memberDataService.removeMemberData(memberId);
+    }
+}

--- a/photo-service/src/main/java/kr/mafoo/photo/domain/AlbumEntity.java
+++ b/photo-service/src/main/java/kr/mafoo/photo/domain/AlbumEntity.java
@@ -47,6 +47,9 @@ public class AlbumEntity implements Persistable<String> {
     @Column("updated_at")
     private LocalDateTime updatedAt;
 
+    @Column("deleted_at")
+    private LocalDateTime deletedAt;
+
     @Transient
     private boolean isNew = false;
 

--- a/photo-service/src/main/java/kr/mafoo/photo/domain/PhotoEntity.java
+++ b/photo-service/src/main/java/kr/mafoo/photo/domain/PhotoEntity.java
@@ -44,6 +44,9 @@ public class PhotoEntity implements Persistable<String> {
     @Column("updated_at")
     private LocalDateTime updatedAt;
 
+    @Column("deleted_at")
+    private LocalDateTime deletedAt;
+
     @Transient
     private boolean isNew = false;
 

--- a/photo-service/src/main/java/kr/mafoo/photo/domain/SharedMemberEntity.java
+++ b/photo-service/src/main/java/kr/mafoo/photo/domain/SharedMemberEntity.java
@@ -42,6 +42,9 @@ public class SharedMemberEntity implements Persistable<String> {
     @Column("updated_at")
     private LocalDateTime updatedAt;
 
+    @Column("deleted_at")
+    private LocalDateTime deletedAt;
+
     @Transient
     private boolean isNew = false;
 

--- a/photo-service/src/main/java/kr/mafoo/photo/repository/AlbumRepository.java
+++ b/photo-service/src/main/java/kr/mafoo/photo/repository/AlbumRepository.java
@@ -1,5 +1,6 @@
 package kr.mafoo.photo.repository;
 
+import java.util.List;
 import kr.mafoo.photo.domain.AlbumEntity;
 import kr.mafoo.photo.domain.enums.AlbumType;
 import org.springframework.data.domain.Pageable;
@@ -18,6 +19,10 @@ public interface AlbumRepository extends R2dbcRepository<AlbumEntity, String> {
     @Modifying
     @Query("UPDATE album SET deleted_at = NOW() WHERE id = :albumId AND deleted_at IS NULL")
     Mono<Void> softDeleteById(String albumId);
+
+    @Modifying
+    @Query("UPDATE album SET deleted_at = NOW() WHERE owner_member_id = :ownerMemberId AND deleted_at IS NULL")
+    Flux<Void> softDeleteByOwnerMemberId(String ownerMemberId);
 
 //    @Modifying
 //    @Query("UPDATE album SET display_index = display_index + 1 WHERE owner_member_id = :ownerMemberId")

--- a/photo-service/src/main/java/kr/mafoo/photo/repository/AlbumRepository.java
+++ b/photo-service/src/main/java/kr/mafoo/photo/repository/AlbumRepository.java
@@ -10,21 +10,28 @@ import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
 public interface AlbumRepository extends R2dbcRepository<AlbumEntity, String> {
-    Flux<AlbumEntity> findAllByOwnerMemberIdOrderByDisplayIndex(String ownerMemberId);
+
+    Mono<AlbumEntity> findByAlbumIdAndDeletedAtIsNull(String albumId);
+
+    Flux<AlbumEntity> findAllByOwnerMemberIdAndDeletedAtIsNullOrderByDisplayIndex(String ownerMemberId);
 
     @Modifying
-    @Query("UPDATE album SET display_index = display_index + 1 WHERE owner_member_id = :ownerMemberId")
-    Mono<Void> pushDisplayIndex(String ownerMemberId);
+    @Query("UPDATE album SET deleted_at = NOW() WHERE id = :albumId AND deleted_at IS NULL")
+    Mono<Void> softDeleteById(String albumId);
 
-    @Modifying
-    @Query("UPDATE album SET display_index = display_index + 1 WHERE owner_member_id = :ownerMemberId " +
-            "AND display_index BETWEEN :startIndex AND :lastIndex")
-    Mono<Void> pushDisplayIndexBetween(String ownerMemberId, Integer startIndex, Integer lastIndex);
-
-    @Modifying
-    @Query("UPDATE album SET display_index = display_index -1 WHERE owner_member_id = :ownerMemberId " +
-            "AND display_index BETWEEN :startIndex AND :lastIndex")
-    Mono<Void> popDisplayIndexBetween(String ownerMemberId, Integer startIndex, Integer lastIndex);
+//    @Modifying
+//    @Query("UPDATE album SET display_index = display_index + 1 WHERE owner_member_id = :ownerMemberId")
+//    Mono<Void> pushDisplayIndex(String ownerMemberId);
+//
+//    @Modifying
+//    @Query("UPDATE album SET display_index = display_index + 1 WHERE owner_member_id = :ownerMemberId " +
+//            "AND display_index BETWEEN :startIndex AND :lastIndex")
+//    Mono<Void> pushDisplayIndexBetween(String ownerMemberId, Integer startIndex, Integer lastIndex);
+//
+//    @Modifying
+//    @Query("UPDATE album SET display_index = display_index -1 WHERE owner_member_id = :ownerMemberId " +
+//            "AND display_index BETWEEN :startIndex AND :lastIndex")
+//    Mono<Void> popDisplayIndexBetween(String ownerMemberId, Integer startIndex, Integer lastIndex);
 
     Flux<AlbumEntity> findAllByOrderByAlbumIdDesc(Pageable pageable);
 

--- a/photo-service/src/main/java/kr/mafoo/photo/repository/PhotoRepository.java
+++ b/photo-service/src/main/java/kr/mafoo/photo/repository/PhotoRepository.java
@@ -10,23 +10,34 @@ import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
 public interface PhotoRepository extends R2dbcRepository<PhotoEntity, String> {
-    Flux<PhotoEntity> findAllByAlbumIdOrderByDisplayIndexDesc(String ownerAlbumId);
 
-    Flux<PhotoEntity> findAllByAlbumIdOrderByCreatedAtDesc(String ownerAlbumId);
+    Mono<PhotoEntity> findByIdAndDeletedAtIsNull(String id);
 
-    Flux<PhotoEntity> findAllByAlbumIdOrderByCreatedAtAsc(String ownerAlbumId);
+    Flux<PhotoEntity> findAllByAlbumIdAndDeletedAtIsNullOrderByDisplayIndexDesc(String ownerAlbumId);
 
-    @Modifying
-    @Query("UPDATE photo SET display_index = display_index - 1 WHERE album_id = :albumId AND display_index > :startIndex")
-    Mono<Void> popDisplayIndexGreaterThan(String albumId, int startIndex);
+    Flux<PhotoEntity> findAllByAlbumIdAndDeletedAtIsNullOrderByCreatedAtDesc(String ownerAlbumId);
 
-    @Modifying
-    @Query("UPDATE photo SET display_index = display_index - 1 WHERE album_id = :albumId AND display_index BETWEEN :startIndex AND :endIndex")
-    Mono<Void> popDisplayIndexBetween(String albumId, int startIndex, int endIndex);
+    Flux<PhotoEntity> findAllByAlbumIdAndDeletedAtIsNullOrderByCreatedAtAsc(String ownerAlbumId);
 
     @Modifying
-    @Query("UPDATE photo SET display_index = display_index + 1 WHERE album_id = :albumId AND display_index BETWEEN :startIndex AND :endIndex")
-    Mono<Void> pushDisplayIndexBetween(String albumId, int startIndex, int endIndex);
+    @Query("UPDATE photo SET display_index = display_index - 1 WHERE album_id = :albumId AND display_index > :startIndex AND deleted_at IS NULL")
+    Flux<Void> updateAllByAlbumIdToDecreaseDisplayIndexGreaterThan(String albumId, int startIndex);
+
+    @Modifying
+    @Query("UPDATE photo SET display_index = display_index - 1 WHERE album_id = :albumId AND display_index BETWEEN :startIndex AND :endIndex AND deleted_at IS NULL")
+    Flux<Void> updateAllByAlbumIdToDecreaseDisplayIndexBetween(String albumId, int startIndex, int endIndex);
+
+    @Modifying
+    @Query("UPDATE photo SET display_index = display_index + 1 WHERE album_id = :albumId AND display_index BETWEEN :startIndex AND :endIndex AND deleted_at IS NULL")
+    Flux<Void> updateAllByAlbumIdToIncreaseDisplayIndexBetween(String albumId, int startIndex, int endIndex);
+
+    @Modifying
+    @Query("UPDATE photo SET deleted_at = NOW() WHERE id = :photoId AND deleted_at IS NULL")
+    Mono<Void> softDeleteById(String photoId);
+
+    @Modifying
+    @Query("UPDATE photo SET deleted_at = NOW() WHERE album_id = :albumId AND deleted_at IS NULL")
+    Flux<Void> softDeleteByAlbumId(String albumId);
 
     Flux<PhotoEntity> findAllByOrderByPhotoIdDesc(Pageable pageable);
     Flux<PhotoEntity> findAllByBrandOrderByPhotoIdDesc(BrandType brandType, Pageable pageable);

--- a/photo-service/src/main/java/kr/mafoo/photo/repository/PhotoRepository.java
+++ b/photo-service/src/main/java/kr/mafoo/photo/repository/PhotoRepository.java
@@ -39,6 +39,10 @@ public interface PhotoRepository extends R2dbcRepository<PhotoEntity, String> {
     @Query("UPDATE photo SET deleted_at = NOW() WHERE album_id = :albumId AND deleted_at IS NULL")
     Flux<Void> softDeleteByAlbumId(String albumId);
 
+    @Modifying
+    @Query("UPDATE photo SET deleted_at = NOW() WHERE owner_member_id = :ownerMemberId AND deleted_at IS NULL")
+    Flux<Void> softDeleteByOwnerMemberId(String ownerMemberId);
+
     Flux<PhotoEntity> findAllByOrderByPhotoIdDesc(Pageable pageable);
     Flux<PhotoEntity> findAllByBrandOrderByPhotoIdDesc(BrandType brandType, Pageable pageable);
     Flux<PhotoEntity> findAllByOwnerMemberIdOrderByPhotoIdDesc(String ownerMemberId, Pageable pageable);

--- a/photo-service/src/main/java/kr/mafoo/photo/repository/SharedMemberRepository.java
+++ b/photo-service/src/main/java/kr/mafoo/photo/repository/SharedMemberRepository.java
@@ -1,5 +1,6 @@
 package kr.mafoo.photo.repository;
 
+import java.util.List;
 import kr.mafoo.photo.domain.SharedMemberEntity;
 import kr.mafoo.photo.domain.enums.ShareStatus;
 import org.springframework.data.r2dbc.repository.Modifying;
@@ -29,4 +30,12 @@ public interface SharedMemberRepository extends R2dbcRepository<SharedMemberEnti
     @Modifying
     @Query("UPDATE shared_member SET deleted_at = NOW() WHERE album_id = :albumId AND deleted_at IS NULL")
     Flux<Void> softDeleteByAlbumId(String albumId);
+
+    @Modifying
+    @Query("UPDATE shared_member SET deleted_at = NOW() WHERE album_id IN (:albumIds) AND deleted_at IS NULL")
+    Flux<Void> softDeleteByAlbumIds(List<String> albumIds);
+
+    @Modifying
+    @Query("UPDATE shared_member SET deleted_at = NOW() WHERE member_id = :memberId AND deleted_at IS NULL")
+    Flux<Void> softDeleteByMemberId(String memberId);
 }

--- a/photo-service/src/main/java/kr/mafoo/photo/repository/SharedMemberRepository.java
+++ b/photo-service/src/main/java/kr/mafoo/photo/repository/SharedMemberRepository.java
@@ -2,6 +2,8 @@ package kr.mafoo.photo.repository;
 
 import kr.mafoo.photo.domain.SharedMemberEntity;
 import kr.mafoo.photo.domain.enums.ShareStatus;
+import org.springframework.data.r2dbc.repository.Modifying;
+import org.springframework.data.r2dbc.repository.Query;
 import org.springframework.data.r2dbc.repository.R2dbcRepository;
 import org.springframework.stereotype.Repository;
 import reactor.core.publisher.Flux;
@@ -9,8 +11,22 @@ import reactor.core.publisher.Mono;
 
 @Repository
 public interface SharedMemberRepository extends R2dbcRepository<SharedMemberEntity, String> {
-    Flux<SharedMemberEntity> findAllByAlbumIdAndShareStatusNot(String albumId, ShareStatus status);
-    Flux<SharedMemberEntity> findAllByMemberIdAndShareStatusNot(String memberId, ShareStatus status);
-    Mono<SharedMemberEntity> findByAlbumIdAndMemberIdAndShareStatus(String albumId, String memberId, ShareStatus status);
-    Mono<SharedMemberEntity> findByAlbumIdAndMemberId(String albumId, String memberId);
+
+    Mono<SharedMemberEntity> findByIdAndDeletedAtIsNull(String id);
+
+    Mono<SharedMemberEntity> findByAlbumIdAndMemberIdAndShareStatusAndDeletedAtIsNull(String albumId, String memberId, ShareStatus status);
+
+    Mono<SharedMemberEntity> findByAlbumIdAndMemberIdAndDeletedAtIsNull(String albumId, String memberId);
+
+    Flux<SharedMemberEntity> findAllByAlbumIdAndShareStatusNotAndDeletedAtIsNull(String albumId, ShareStatus status);
+
+    Flux<SharedMemberEntity> findAllByMemberIdAndShareStatusNotAndDeletedAtIsNull(String memberId, ShareStatus status);
+
+    @Modifying
+    @Query("UPDATE shared_member SET deleted_at = NOW() WHERE id = :sharedMemberId AND deleted_at IS NULL")
+    Mono<Void> softDeleteById(String sharedMemberId);
+
+    @Modifying
+    @Query("UPDATE shared_member SET deleted_at = NOW() WHERE album_id = :albumId AND deleted_at IS NULL")
+    Flux<Void> softDeleteByAlbumId(String albumId);
 }

--- a/photo-service/src/main/java/kr/mafoo/photo/service/AlbumCommand.java
+++ b/photo-service/src/main/java/kr/mafoo/photo/service/AlbumCommand.java
@@ -1,11 +1,13 @@
 package kr.mafoo.photo.service;
 
+import java.util.List;
 import kr.mafoo.photo.domain.AlbumEntity;
 import kr.mafoo.photo.domain.enums.AlbumType;
 import kr.mafoo.photo.repository.AlbumRepository;
 import kr.mafoo.photo.util.IdGenerator;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
 @Service
@@ -41,6 +43,10 @@ public class AlbumCommand {
 
     public Mono<Void> removeAlbum(String albumId) {
         return albumRepository.softDeleteById(albumId);
+    }
+
+    public Flux<Void> removeAlbumByOwnerMemberId(String ownerMemberId) {
+        return albumRepository.softDeleteByOwnerMemberId(ownerMemberId);
     }
 
 }

--- a/photo-service/src/main/java/kr/mafoo/photo/service/AlbumCommand.java
+++ b/photo-service/src/main/java/kr/mafoo/photo/service/AlbumCommand.java
@@ -39,8 +39,8 @@ public class AlbumCommand {
         return albumRepository.save(album.decreasePhotoCount(count));
     }
 
-    public Mono<Void> removeAlbum(AlbumEntity album) {
-        return albumRepository.delete(album);
+    public Mono<Void> removeAlbum(String albumId) {
+        return albumRepository.softDeleteById(albumId);
     }
 
 }

--- a/photo-service/src/main/java/kr/mafoo/photo/service/AlbumQuery.java
+++ b/photo-service/src/main/java/kr/mafoo/photo/service/AlbumQuery.java
@@ -1,6 +1,5 @@
 package kr.mafoo.photo.service;
 
-import java.time.Duration;
 import kr.mafoo.photo.domain.AlbumEntity;
 import kr.mafoo.photo.domain.enums.AlbumType;
 import kr.mafoo.photo.exception.AlbumNotFoundException;
@@ -21,12 +20,12 @@ public class AlbumQuery {
     private final AlbumRepository albumRepository;
 
     public Mono<AlbumEntity> findById(String albumId) {
-        return albumRepository.findById(albumId)
+        return albumRepository.findByAlbumIdAndDeletedAtIsNull(albumId)
             .switchIfEmpty(Mono.error(new AlbumNotFoundException()));
     }
 
     public Flux<AlbumEntity> findByMemberId(String memberId) {
-        return albumRepository.findAllByOwnerMemberIdOrderByDisplayIndex(memberId)
+        return albumRepository.findAllByOwnerMemberIdAndDeletedAtIsNullOrderByDisplayIndex(memberId)
             .switchIfEmpty(Mono.error(new AlbumNotFoundException()));
     }
 

--- a/photo-service/src/main/java/kr/mafoo/photo/service/EventService.java
+++ b/photo-service/src/main/java/kr/mafoo/photo/service/EventService.java
@@ -1,0 +1,57 @@
+package kr.mafoo.photo.service;
+
+import java.util.concurrent.atomic.AtomicInteger;
+import kr.mafoo.photo.domain.AlbumEntity;
+import kr.mafoo.photo.domain.enums.BrandType;
+import kr.mafoo.photo.exception.AlbumNotFoundException;
+import kr.mafoo.photo.repository.AlbumRepository;
+import kr.mafoo.photo.repository.SumoneEventMappingRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import reactor.core.publisher.Mono;
+
+@RequiredArgsConstructor
+@Service
+public class EventService {
+
+    private final AlbumRepository albumRepository;
+
+    private final PhotoQuery photoQuery;
+    private final PhotoCommand photoCommand;
+
+    private final AlbumQuery albumQuery;
+    private final AlbumCommand albumCommand;
+
+    private final SumoneEventMappingRepository sumoneEventMappingRepository;
+
+    @Transactional
+    public Mono<AlbumEntity> addSumoneAlbum(String albumName, String albumType, String requestMemberId, String inviteCode) {
+        AtomicInteger displayIndex = new AtomicInteger(0);
+        return albumCommand
+            .addAlbum(albumName, albumType, requestMemberId, null)
+            .flatMap(album -> sumoneEventMappingRepository
+                .findByInviteCode(inviteCode)
+                .switchIfEmpty(Mono.error(new AlbumNotFoundException()))
+                .flatMap(sumoneEventMappingEntity ->
+                    sumoneEventMappingRepository.delete(sumoneEventMappingEntity).then(Mono.just(sumoneEventMappingEntity)))
+                .map(entity -> "SUMONE_" + entity.getId())
+                .flatMapMany(albumRepository::findAllByExternalId)
+                .flatMap(sumoneAlbum ->
+                    photoQuery.findAllByAlbumIdOrderByCreatedAtAsc(sumoneAlbum.getAlbumId())
+                        .flatMap(photo ->
+                            photoCommand.addPhoto(
+                                photo.getPhotoUrl(),
+                                BrandType.EXTERNAL,
+                                album.getAlbumId(),
+                                displayIndex.getAndIncrement(),
+                                requestMemberId
+                            )
+                        )
+                )
+                .then(albumQuery.findById(album.getAlbumId()))
+                .flatMap(newAlbum -> albumCommand.increaseAlbumPhotoCount(newAlbum, displayIndex.get())));
+    }
+
+
+}

--- a/photo-service/src/main/java/kr/mafoo/photo/service/MemberDataService.java
+++ b/photo-service/src/main/java/kr/mafoo/photo/service/MemberDataService.java
@@ -1,0 +1,44 @@
+package kr.mafoo.photo.service;
+
+import java.util.List;
+import kr.mafoo.photo.domain.AlbumEntity;
+import kr.mafoo.photo.exception.AlbumNotFoundException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class MemberDataService {
+
+    private final AlbumQuery albumQuery;
+    private final AlbumCommand albumCommand;
+
+    private final PhotoCommand photoCommand;
+
+    private final SharedMemberCommand sharedMemberCommand;
+
+    @Transactional
+    public Flux<Void> removeMemberData(String requestMemberId) {
+        return sharedMemberCommand.removeShareMemberByMemberId(requestMemberId)
+            .thenMany(
+                albumQuery.findByMemberId(requestMemberId)
+                    .onErrorResume(AlbumNotFoundException.class, ex -> Mono.empty())
+                    .collectList()
+                    .filter(albumList -> !albumList.isEmpty())
+                    .flatMapMany(albumList -> {
+                        List<String> albumIdList = albumList.stream().map(AlbumEntity::getAlbumId).toList();
+
+                        return Mono.when(
+                            sharedMemberCommand.removeShareMemberByAlbumIds(albumIdList),
+                            photoCommand.removePhotoByOwnerMemberId(requestMemberId),
+                            albumCommand.removeAlbumByOwnerMemberId(requestMemberId)
+                        );
+                    })
+            );
+    }
+}

--- a/photo-service/src/main/java/kr/mafoo/photo/service/PhotoCommand.java
+++ b/photo-service/src/main/java/kr/mafoo/photo/service/PhotoCommand.java
@@ -7,6 +7,7 @@ import kr.mafoo.photo.util.IdGenerator;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
+import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
 @Slf4j
@@ -36,13 +37,31 @@ public class PhotoCommand {
         );
     }
 
-    public Mono<Void> removePhoto(PhotoEntity photo) {
-        return popDisplayIndexGreaterThan(photo.getAlbumId(), photo.getDisplayIndex())
-            .then(photoRepository.delete(photo));
+    public Mono<PhotoEntity> modifyPhotoDisplayIndex(PhotoEntity photo, Integer newDisplayIndex) {
+        return photoRepository.save(
+            photo.updateDisplayIndex(newDisplayIndex)
+        );
     }
 
-    public Mono<Void> popDisplayIndexGreaterThan(String albumId, int startIndex) {
-        return photoRepository.popDisplayIndexGreaterThan(albumId, startIndex);
+    public Flux<Void> modifyPhotosByAlbumIdToDecreaseDisplayIndexGreaterThan(String albumId, int startIndex) {
+        return photoRepository.updateAllByAlbumIdToDecreaseDisplayIndexGreaterThan(albumId, startIndex);
+    }
+
+    public Flux<Void> modifyPhotosByAlbumIdToDecreaseDisplayIndexBetween(String albumId, int startIndex, int endIndex) {
+        return photoRepository.updateAllByAlbumIdToDecreaseDisplayIndexBetween(albumId, startIndex, endIndex);
+    }
+
+    public Flux<Void> modifyPhotosByAlbumIdToIncreaseDisplayIndexBetween(String albumId, int startIndex, int endIndex) {
+        return photoRepository.updateAllByAlbumIdToIncreaseDisplayIndexBetween(albumId, startIndex, endIndex);
+    }
+
+    public Mono<Void> removePhoto(PhotoEntity photo) {
+        return modifyPhotosByAlbumIdToDecreaseDisplayIndexGreaterThan(photo.getAlbumId(), photo.getDisplayIndex())
+            .then(photoRepository.softDeleteById(photo.getPhotoId()));
+    }
+
+    public Flux<Void> removePhotoByAlbumId(String albumId) {
+        return photoRepository.softDeleteByAlbumId(albumId);
     }
 
 }

--- a/photo-service/src/main/java/kr/mafoo/photo/service/PhotoCommand.java
+++ b/photo-service/src/main/java/kr/mafoo/photo/service/PhotoCommand.java
@@ -64,4 +64,8 @@ public class PhotoCommand {
         return photoRepository.softDeleteByAlbumId(albumId);
     }
 
+    public Flux<Void> removePhotoByOwnerMemberId(String ownerMemberId) {
+        return photoRepository.softDeleteByOwnerMemberId(ownerMemberId);
+    }
+
 }

--- a/photo-service/src/main/java/kr/mafoo/photo/service/PhotoQuery.java
+++ b/photo-service/src/main/java/kr/mafoo/photo/service/PhotoQuery.java
@@ -17,22 +17,22 @@ public class PhotoQuery {
     private final PhotoRepository photoRepository;
 
     public Flux<PhotoEntity> findAllByAlbumIdOrderByCreatedAtAsc(String albumId) {
-        return photoRepository.findAllByAlbumIdOrderByCreatedAtAsc(albumId)
+        return photoRepository.findAllByAlbumIdAndDeletedAtIsNullOrderByCreatedAtAsc(albumId)
             .switchIfEmpty(Mono.error(new PhotoNotFoundException()));
     }
 
     public Flux<PhotoEntity> findAllByAlbumIdOrderByCreatedAtDesc(String albumId) {
-        return photoRepository.findAllByAlbumIdOrderByCreatedAtDesc(albumId)
+        return photoRepository.findAllByAlbumIdAndDeletedAtIsNullOrderByCreatedAtDesc(albumId)
             .switchIfEmpty(Mono.error(new PhotoNotFoundException()));
     }
 
     public Flux<PhotoEntity> findAllByAlbumIdOrderByDisplayIndexDesc(String albumId) {
-        return photoRepository.findAllByAlbumIdOrderByDisplayIndexDesc(albumId)
+        return photoRepository.findAllByAlbumIdAndDeletedAtIsNullOrderByDisplayIndexDesc(albumId)
             .switchIfEmpty(Mono.error(new PhotoNotFoundException()));
     }
 
     public Mono<PhotoEntity> findByPhotoId(String photoId) {
-        return photoRepository.findById(photoId)
+        return photoRepository.findByIdAndDeletedAtIsNull(photoId)
             .switchIfEmpty(Mono.error(new PhotoNotFoundException()));
     }
 

--- a/photo-service/src/main/java/kr/mafoo/photo/service/SharedMemberCommand.java
+++ b/photo-service/src/main/java/kr/mafoo/photo/service/SharedMemberCommand.java
@@ -1,5 +1,6 @@
 package kr.mafoo.photo.service;
 
+import java.util.List;
 import java.util.Optional;
 import kr.mafoo.photo.domain.enums.PermissionLevel;
 import kr.mafoo.photo.domain.SharedMemberEntity;
@@ -43,6 +44,14 @@ public class SharedMemberCommand {
 
     public Flux<Void> removeShareMemberByAlbumId(String albumId) {
         return sharedMemberRepository.softDeleteByAlbumId(albumId);
+    }
+
+    public Flux<Void> removeShareMemberByMemberId(String memberId) {
+        return sharedMemberRepository.softDeleteByMemberId(memberId);
+    }
+
+    public Flux<Void> removeShareMemberByAlbumIds(List<String> albumIds) {
+        return sharedMemberRepository.softDeleteByAlbumIds(albumIds);
     }
 
 }

--- a/photo-service/src/main/java/kr/mafoo/photo/service/SharedMemberCommand.java
+++ b/photo-service/src/main/java/kr/mafoo/photo/service/SharedMemberCommand.java
@@ -1,7 +1,5 @@
 package kr.mafoo.photo.service;
 
-import static kr.mafoo.photo.domain.enums.ShareStatus.PENDING;
-
 import java.util.Optional;
 import kr.mafoo.photo.domain.enums.PermissionLevel;
 import kr.mafoo.photo.domain.SharedMemberEntity;
@@ -10,6 +8,7 @@ import kr.mafoo.photo.repository.SharedMemberRepository;
 import kr.mafoo.photo.util.IdGenerator;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
 @RequiredArgsConstructor
@@ -26,10 +25,6 @@ public class SharedMemberCommand {
         );
     }
 
-    public Mono<Void> removeSharedMember(SharedMemberEntity sharedMember) {
-        return sharedMemberRepository.delete(sharedMember);
-    }
-
     public Mono<SharedMemberEntity> modifySharedMemberShareStatus(SharedMemberEntity sharedMember, String newShareStatus) {
         return sharedMemberRepository.save(sharedMember.updateShareStatus(
             ShareStatus.valueOf(newShareStatus)
@@ -40,6 +35,14 @@ public class SharedMemberCommand {
         return sharedMemberRepository.save(sharedMember.updatePermissionLevel(
             PermissionLevel.valueOf(newPermissionLevel)
         ));
+    }
+
+    public Mono<Void> removeSharedMember(SharedMemberEntity sharedMember) {
+        return sharedMemberRepository.softDeleteById(sharedMember.getSharedMemberId());
+    }
+
+    public Flux<Void> removeShareMemberByAlbumId(String albumId) {
+        return sharedMemberRepository.softDeleteByAlbumId(albumId);
     }
 
 }

--- a/photo-service/src/main/java/kr/mafoo/photo/service/SharedMemberQuery.java
+++ b/photo-service/src/main/java/kr/mafoo/photo/service/SharedMemberQuery.java
@@ -19,32 +19,32 @@ public class SharedMemberQuery {
     private final SharedMemberRepository sharedMemberRepository;
 
     public Flux<SharedMemberEntity> findAllByAlbumIdWhereStatusNotRejected(String albumId) {
-        return sharedMemberRepository.findAllByAlbumIdAndShareStatusNot(albumId, REJECTED)
+        return sharedMemberRepository.findAllByAlbumIdAndShareStatusNotAndDeletedAtIsNull(albumId, REJECTED)
             .switchIfEmpty(Mono.error(new SharedMemberNotFoundException()));
     }
 
     public Flux<SharedMemberEntity> findAllByMemberIdWhereStatusNotRejected(String memberId) {
-        return sharedMemberRepository.findAllByMemberIdAndShareStatusNot(memberId, REJECTED)
+        return sharedMemberRepository.findAllByMemberIdAndShareStatusNotAndDeletedAtIsNull(memberId, REJECTED)
             .switchIfEmpty(Mono.error(new SharedMemberNotFoundException()));
     }
 
     public Mono<SharedMemberEntity> findBySharedMemberId(String sharedMemberId) {
-        return sharedMemberRepository.findById(sharedMemberId)
+        return sharedMemberRepository.findByIdAndDeletedAtIsNull(sharedMemberId)
             .switchIfEmpty(Mono.error(new SharedMemberNotFoundException()));
     }
 
     public Mono<SharedMemberEntity> findByAlbumIdAndMemberIdWhereStatusAccepted(String albumId, String memberId) {
-        return sharedMemberRepository.findByAlbumIdAndMemberIdAndShareStatus(albumId, memberId, ACCEPTED)
+        return sharedMemberRepository.findByAlbumIdAndMemberIdAndShareStatusAndDeletedAtIsNull(albumId, memberId, ACCEPTED)
             .switchIfEmpty(Mono.error(new SharedMemberNotFoundException()));
     }
 
     public Mono<SharedMemberEntity> findByAlbumIdAndMemberId(String albumId, String memberId) {
-        return sharedMemberRepository.findByAlbumIdAndMemberId(albumId, memberId)
+        return sharedMemberRepository.findByAlbumIdAndMemberIdAndDeletedAtIsNull(albumId, memberId)
             .switchIfEmpty(Mono.error(new SharedMemberNotFoundException()));
     }
 
     public Mono<Void> checkDuplicateByAlbumIdAndMemberId(String albumId, String memberId) {
-        return sharedMemberRepository.findByAlbumIdAndMemberId(albumId, memberId)
+        return sharedMemberRepository.findByAlbumIdAndMemberIdAndDeletedAtIsNull(albumId, memberId)
             .switchIfEmpty(Mono.empty())
             .flatMap(existingMember -> Mono.error(new SharedMemberDuplicatedException()));
     }

--- a/photo-service/src/main/resources/db/migration/V14__addDeletedAtFieldInAllTables.sql
+++ b/photo-service/src/main/resources/db/migration/V14__addDeletedAtFieldInAllTables.sql
@@ -1,0 +1,8 @@
+ALTER TABLE `photo`
+    ADD `deleted_at` TIMESTAMP NULL COMMENT '삭제여부' after `updated_at`;
+
+ALTER TABLE `album`
+    ADD `deleted_at` TIMESTAMP NULL COMMENT '삭제여부' after `updated_at`;
+
+ALTER TABLE `shared_member`
+    ADD `deleted_at` TIMESTAMP NULL COMMENT '삭제여부' after `updated_at`;

--- a/user-service/src/main/java/kr/mafoo/user/api/AuthApi.java
+++ b/user-service/src/main/java/kr/mafoo/user/api/AuthApi.java
@@ -11,7 +11,6 @@ import kr.mafoo.user.controller.dto.response.LoginResponse;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.server.ServerWebExchange;
 import reactor.core.publisher.Mono;

--- a/user-service/src/main/java/kr/mafoo/user/api/MeApi.java
+++ b/user-service/src/main/java/kr/mafoo/user/api/MeApi.java
@@ -6,6 +6,7 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import kr.mafoo.user.annotation.RequestMemberId;
 import kr.mafoo.user.controller.dto.request.ChangeNameRequest;
 import kr.mafoo.user.controller.dto.response.MemberResponse;
+import org.springframework.http.server.reactive.ServerHttpRequest;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 import reactor.core.publisher.Mono;
@@ -23,7 +24,8 @@ public interface MeApi {
     @Operation(summary = "탈퇴", description = "현재 토큰 주인이 탈퇴합니다.")
     @DeleteMapping
     Mono<Void> deleteMemberWhoRequested(
-            @RequestMemberId @Parameter(hidden = true) String memberId
+            @RequestMemberId @Parameter(hidden = true) String memberId,
+            ServerHttpRequest serverHttpRequest
     );
 
     @Operation(summary = "이름 변경", description = "현재 토큰 주인의 이름을 변경합니다.")

--- a/user-service/src/main/java/kr/mafoo/user/controller/MeController.java
+++ b/user-service/src/main/java/kr/mafoo/user/controller/MeController.java
@@ -5,6 +5,7 @@ import kr.mafoo.user.controller.dto.request.ChangeNameRequest;
 import kr.mafoo.user.controller.dto.response.MemberResponse;
 import kr.mafoo.user.service.MemberService;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.server.reactive.ServerHttpRequest;
 import org.springframework.web.bind.annotation.RestController;
 import reactor.core.publisher.Mono;
 
@@ -21,9 +22,14 @@ public class MeController implements MeApi {
     }
 
     @Override
-    public Mono<Void> deleteMemberWhoRequested(String memberId) {
+    public Mono<Void> deleteMemberWhoRequested(
+        String memberId,
+        ServerHttpRequest serverHttpRequest
+    ) {
+        String authorizationToken = serverHttpRequest.getHeaders().getFirst("Authorization");
+
         return memberService
-                .quitMemberByMemberId(memberId);
+                .quitMemberByMemberId(memberId, authorizationToken);
     }
 
     @Override

--- a/user-service/src/main/java/kr/mafoo/user/domain/MemberEntity.java
+++ b/user-service/src/main/java/kr/mafoo/user/domain/MemberEntity.java
@@ -29,11 +29,14 @@ public class MemberEntity implements Persistable<String> {
     @Column("serial_number")
     private Integer serialNumber;
 
+    @Column("profile_img_url")
+    private String profileImageUrl;
+
     @Column("created_at")
     private LocalDateTime createdAt;
 
-    @Column("profile_img_url")
-    private String profileImageUrl;
+    @Column("deleted_at")
+    private LocalDateTime deletedAt;
 
     @Transient
     private boolean isNew = false;

--- a/user-service/src/main/java/kr/mafoo/user/domain/SocialMemberEntity.java
+++ b/user-service/src/main/java/kr/mafoo/user/domain/SocialMemberEntity.java
@@ -1,11 +1,11 @@
 package kr.mafoo.user.domain;
 
+import kr.mafoo.user.domain.key.SocialMemberEntityKey;
 import kr.mafoo.user.enums.IdentityProvider;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 import org.springframework.data.annotation.CreatedDate;
-import org.springframework.data.annotation.Id;
 import org.springframework.data.annotation.Transient;
 import org.springframework.data.domain.Persistable;
 import org.springframework.data.relational.core.mapping.Column;
@@ -25,12 +25,15 @@ public class SocialMemberEntity implements Persistable<SocialMemberEntityKey> {
     @Column("identifier")
     private String id;
 
+    @Column("member_id")
+    private String memberId;
+
     @CreatedDate
     @Column("created_at")
     private LocalDateTime createdAt;
 
-    @Column("member_id")
-    private String memberId;
+    @Column("deleted_at")
+    private LocalDateTime deletedAt;
 
     @Transient
     private boolean isNew = false;

--- a/user-service/src/main/java/kr/mafoo/user/domain/key/SocialMemberEntityKey.java
+++ b/user-service/src/main/java/kr/mafoo/user/domain/key/SocialMemberEntityKey.java
@@ -1,4 +1,4 @@
-package kr.mafoo.user.domain;
+package kr.mafoo.user.domain.key;
 
 import kr.mafoo.user.enums.IdentityProvider;
 import lombok.Data;

--- a/user-service/src/main/java/kr/mafoo/user/repository/MemberRepository.java
+++ b/user-service/src/main/java/kr/mafoo/user/repository/MemberRepository.java
@@ -1,11 +1,19 @@
 package kr.mafoo.user.repository;
 
 import kr.mafoo.user.domain.MemberEntity;
+import org.springframework.data.r2dbc.repository.Modifying;
+import org.springframework.data.r2dbc.repository.Query;
 import org.springframework.data.r2dbc.repository.R2dbcRepository;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
 public interface MemberRepository extends R2dbcRepository<MemberEntity, String> {
-    Flux<MemberEntity> findAllByNameContaining(String memberId);
-    Mono<Void> deleteMemberById(String memberId);
+
+    Mono<MemberEntity> findByIdAndDeletedAtIsNull(String memberId);
+
+    Flux<MemberEntity> findAllByNameContainingAndDeletedAtIsNull(String keyword);
+
+    @Modifying
+    @Query("UPDATE member SET deleted_at = NOW() WHERE member_id = :memberId AND deleted_at IS NULL")
+    Mono<Void> softDeleteById(String memberId);
 }

--- a/user-service/src/main/java/kr/mafoo/user/repository/SocialMemberRepository.java
+++ b/user-service/src/main/java/kr/mafoo/user/repository/SocialMemberRepository.java
@@ -1,12 +1,20 @@
 package kr.mafoo.user.repository;
 
 import kr.mafoo.user.domain.SocialMemberEntity;
-import kr.mafoo.user.domain.SocialMemberEntityKey;
+import kr.mafoo.user.domain.key.SocialMemberEntityKey;
 import kr.mafoo.user.enums.IdentityProvider;
+import org.springframework.data.r2dbc.repository.Modifying;
+import org.springframework.data.r2dbc.repository.Query;
 import org.springframework.data.r2dbc.repository.R2dbcRepository;
+import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
 public interface SocialMemberRepository extends R2dbcRepository<SocialMemberEntity, SocialMemberEntityKey> {
-    Mono<SocialMemberEntity> findByIdentityProviderAndId(IdentityProvider identityProvider, String id);
-    Mono<Void> deleteSocialMemberByMemberId(String memberId);
+
+    Mono<SocialMemberEntity> findByIdentityProviderAndIdAndDeletedAtIsNull(IdentityProvider identityProvider, String id);
+
+    @Modifying
+    @Query("UPDATE social_member SET deleted_at = NOW() WHERE member_id = :memberId AND deleted_at IS NULL")
+    Flux<Void> softDeleteByMemberId(String memberId);
+
 }

--- a/user-service/src/main/java/kr/mafoo/user/service/AuthService.java
+++ b/user-service/src/main/java/kr/mafoo/user/service/AuthService.java
@@ -92,7 +92,7 @@ public class AuthService {
 
     private Mono<AuthToken> getOrCreateMember(IdentityProvider provider, String id, String username, String profileImageUrl, String userAgent) {
         return socialMemberRepository
-                .findByIdentityProviderAndId(provider, id)
+                .findByIdentityProviderAndIdAndDeletedAtIsNull(provider, id)
                 .switchIfEmpty(createNewSocialMember(provider, id, username, profileImageUrl, userAgent))
                 .map(socialMember -> {
                     String accessToken = jwtTokenService.generateAccessToken(socialMember.getMemberId());

--- a/user-service/src/main/java/kr/mafoo/user/service/MemberDataService.java
+++ b/user-service/src/main/java/kr/mafoo/user/service/MemberDataService.java
@@ -1,0 +1,32 @@
+package kr.mafoo.user.service;
+import kr.mafoo.user.exception.MafooPhotoApiFailedException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.web.reactive.function.client.WebClient;
+import reactor.core.publisher.Mono;
+
+@RequiredArgsConstructor
+@Service
+public class MemberDataService {
+
+    @Value("${app.gateway.endpoint}")
+    private String endpoint;
+
+    private final WebClient client;
+
+    public Mono<Void> deleteMemberData(String authorizationToken) {
+        return client
+            .delete()
+            .uri(endpoint + "/photo/v1/member-data")
+            .header("Authorization", "Bearer " + authorizationToken)
+            .retrieve()
+            .onStatus(status -> status.isSameCodeAs(HttpStatus.BAD_REQUEST), (res) -> Mono.empty())
+            .onStatus(status -> !status.is2xxSuccessful(), (res) -> Mono.error(new MafooPhotoApiFailedException()))
+            .toBodilessEntity()
+            .then();
+    }
+
+}
+

--- a/user-service/src/main/resources/db/migration/V5__add_deleted_at_field.sql
+++ b/user-service/src/main/resources/db/migration/V5__add_deleted_at_field.sql
@@ -1,0 +1,5 @@
+ALTER TABLE member
+    ADD deleted_at TIMESTAMP NULL COMMENT '삭제여부' after created_at;
+
+ALTER TABLE social_member
+    ADD deleted_at TIMESTAMP NULL COMMENT '삭제여부' after created_at;


### PR DESCRIPTION
## ❓ 기능 추가 배경
SOFT DELETE이 가능하도록 전반적인 로직을 수정했어요

## ➕ 추가/변경된 기능
- [X] photo-service : deleted_at 필드로 삭제 여부를 구분하도록 수정
- [x] user-service : deleted_at 필드로 삭제 여부를 구분하도록 수정 + 회원 탈퇴 시 photo-service 데이터 잔류로 발생하는 오류 해결

## 🥺 리뷰어에게 하고싶은 말
진작 수정해둘 걸 그랬네요~ 😇

## 🗎 관련 이슈
[M25-22](https://3spinachpasta.atlassian.net/browse/M25-22)