### PR TITLE
[M25-24] feat: 마푸 리캡 관련 API를 AWS Lambda를 사용하는 새로운 로직에 맞춰 변경했어요

### DIFF
--- a/photo-service/src/main/java/kr/mafoo/photo/api/ObjectStorageApi.java
+++ b/photo-service/src/main/java/kr/mafoo/photo/api/ObjectStorageApi.java
@@ -27,6 +27,9 @@ public interface ObjectStorageApi {
     @Operation(summary = "리캡 Pre-signed Url 요청", description = "리캡 생성을 위한 Pre-signed Url 목록을 발급합니다.")
     @PostMapping("/recap")
     Mono<PreSignedUrlResponse> createRecapPreSignedUrls(
+            @RequestMemberId
+            String memberId,
+
             @RequestBody
             ObjectStoragePreSignedUrlRequest request
     );

--- a/photo-service/src/main/java/kr/mafoo/photo/api/RecapApi.java
+++ b/photo-service/src/main/java/kr/mafoo/photo/api/RecapApi.java
@@ -17,26 +17,26 @@ import reactor.core.publisher.Mono;
 @Tag(name = "리캡 관련 API", description = "리캡 생성 API")
 @RequestMapping("/v1/recaps")
 public interface RecapApi {
-    @Operation(summary = "(구 버전) 리캡 생성", description = "앨범의 리캡을 생성합니다.")
-    @PostMapping
-    Mono<RecapResponse> createRecapOriginal(
-        @RequestMemberId
-        String memberId,
-
-        @Valid
-        @RequestBody
-        RecapCreateRequestOld request,
-
-        @Parameter(description = "정렬 종류", example = "ASC | DESC")
-        @RequestParam(required = false)
-        String sort,
-
-        // Authorization Header를 받아올 목적
-        ServerHttpRequest serverHttpRequest
-    );
+//    @Operation(summary = "(구 버전) 리캡 생성", description = "앨범의 리캡을 생성합니다.")
+//    @PostMapping
+//    Mono<RecapResponse> createRecapOriginal(
+//        @RequestMemberId
+//        String memberId,
+//
+//        @Valid
+//        @RequestBody
+//        RecapCreateRequestOld request,
+//
+//        @Parameter(description = "정렬 종류", example = "ASC | DESC")
+//        @RequestParam(required = false)
+//        String sort,
+//
+//        // Authorization Header를 받아올 목적
+//        ServerHttpRequest serverHttpRequest
+//    );
 
     @Operation(summary = "리캡 비디오 생성", description = "리캡 영상을 생성합니다.")
-    @PostMapping("/video")
+    @PostMapping
     Mono<RecapResponse> createRecapVideo(
         @RequestMemberId
         String memberId,

--- a/photo-service/src/main/java/kr/mafoo/photo/controller/ObjectStorageController.java
+++ b/photo-service/src/main/java/kr/mafoo/photo/controller/ObjectStorageController.java
@@ -26,6 +26,7 @@ public class ObjectStorageController implements ObjectStorageApi {
 
     @Override
     public Mono<PreSignedUrlResponse> createRecapPreSignedUrls(
+        String memberId,
         ObjectStoragePreSignedUrlRequest request
     ) {
         return objectStorageService

--- a/photo-service/src/main/java/kr/mafoo/photo/controller/RecapController.java
+++ b/photo-service/src/main/java/kr/mafoo/photo/controller/RecapController.java
@@ -2,12 +2,9 @@ package kr.mafoo.photo.controller;
 
 import kr.mafoo.photo.api.RecapApi;
 import kr.mafoo.photo.controller.dto.request.RecapCreateRequest;
-import kr.mafoo.photo.controller.dto.request.RecapCreateRequestOld;
 import kr.mafoo.photo.controller.dto.response.RecapResponse;
-import kr.mafoo.photo.service.RecapService;
-import kr.mafoo.photo.service.RecapServiceOld;
+import kr.mafoo.photo.service.RecapLambdaService;
 import lombok.RequiredArgsConstructor;
-import org.springframework.http.server.reactive.ServerHttpRequest;
 import org.springframework.web.bind.annotation.RestController;
 import reactor.core.publisher.Mono;
 
@@ -15,28 +12,14 @@ import reactor.core.publisher.Mono;
 @RestController
 public class RecapController implements RecapApi {
 
-    private final RecapServiceOld recapServiceOld;
-    private final RecapService recapService;
-
-    @Override
-    public Mono<RecapResponse> createRecapOriginal(
-            String memberId,
-            RecapCreateRequestOld request,
-            String sort,
-            ServerHttpRequest serverHttpRequest
-    ) {
-        String authorizationToken = serverHttpRequest.getHeaders().getFirst("Authorization");
-
-        return recapServiceOld.createRecap(request.albumId(), memberId, sort, authorizationToken)
-                .map(RecapResponse::fromString);
-    }
+    private final RecapLambdaService recapLambdaService;
 
     @Override
     public Mono<RecapResponse> createRecapVideo(
         String memberId,
         RecapCreateRequest request
     ) {
-        return recapService.generateRecapVideo(request.fileUrls(), request.albumId(), memberId)
+        return recapLambdaService.generateMafooRecapVideo(request.fileUrls(), request.albumId(), memberId)
             .map(RecapResponse::fromDto);
     }
 

--- a/photo-service/src/main/java/kr/mafoo/photo/service/RecapLambdaService.java
+++ b/photo-service/src/main/java/kr/mafoo/photo/service/RecapLambdaService.java
@@ -1,5 +1,7 @@
 package kr.mafoo.photo.service;
 
+import static kr.mafoo.photo.domain.enums.PermissionLevel.DOWNLOAD_ACCESS;
+
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -12,10 +14,22 @@ import reactor.core.publisher.Mono;
 
 @Service
 public class RecapLambdaService {
-    private final WebClient client;
 
-    public RecapLambdaService(@Qualifier("recapLambdaClient") WebClient client) {
+    private final WebClient client;
+    private final AlbumPermissionVerifier albumPermissionVerifier;
+
+    public RecapLambdaService(
+        @Qualifier("recapLambdaClient")
+        WebClient client,
+        AlbumPermissionVerifier albumPermissionVerifier
+    ) {
         this.client = client;
+        this.albumPermissionVerifier = albumPermissionVerifier;
+    }
+
+    public Mono<RecapUrlDto> generateMafooRecapVideo(List<String> recapPhotoUrls, String albumId, String requestMemberId) {
+        return albumPermissionVerifier.verifyOwnershipOrAccessPermission(albumId, requestMemberId, DOWNLOAD_ACCESS)
+                .then(generateVideo(recapPhotoUrls));
     }
 
     public Mono<RecapUrlDto> generateVideo(List<String> recapPhotoUrls) {


### PR DESCRIPTION
## ❓ 기능 추가 배경
마푸 리캡 관련 API를 AWS Lambda를 사용하는 새로운 로직에 맞춰 변경했어요

## ➕ 추가/변경된 기능
- 리캡 presigned-url 발급 API : Authorization token 필수로 변경
- 리캡 영상 생성 API : 람다 함수 사용하는 메소드로 변경 + 다운로드 권한을 가진 사용자만 접근 가능하도록 설정

## 🥺 리뷰어에게 하고싶은 말
파이팅

## 🗎 관련 이슈
[M25-24](https://3spinachpasta.atlassian.net/browse/M25-24)